### PR TITLE
fix Attribute Error accessing translatePath

### DIFF
--- a/resources/utils.py
+++ b/resources/utils.py
@@ -13,7 +13,7 @@ def data_dir():
     """"get user data directory of this addon. 
     according to http://wiki.xbmc.org/index.php?title=Add-on_Rules#Requirements_for_scripts_and_plugins
     """
-    __datapath__ = xbmc.translatePath( __Addon.getAddonInfo('profile') )
+    __datapath__ = xbmcvfs.translatePath( __Addon.getAddonInfo('profile') )
     if not xbmcvfs.exists(__datapath__):
         xbmcvfs.mkdir(__datapath__)
     return __datapath__


### PR DESCRIPTION
Hi,

I just installed Kodi v20 and I get this error using the dropbox authentication in the watchedList add-on:
```
 error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
   Error Type: <class 'AttributeError'>
   Error Contents: module 'xbmc' has no attribute 'translatePath'
   Traceback (most recent call last):
     File "/Users/krf/Library/Application Support/Kodi/addons/script.module.dropbox_auth/authenticate.py", line 96, in <module>
       mydisplay = MyClass(authorize_url)
                   ^^^^^^^^^^^^^^^^^^^^^^
     File "/Users/krf/Library/Application Support/Kodi/addons/script.module.dropbox_auth/authenticate.py", line 57, in __init__
       tmp_dir = os.path.join(utils.data_dir()) # tmp_dir has to exist
                              ^^^^^^^^^^^^^^^^
     File "/Users/krf/Library/Application Support/Kodi/addons/script.module.dropbox_auth/resources/utils.py", line 16, in data_dir
       __datapath__ = xbmc.translatePath( __Addon.getAddonInfo('profile') )
                      ^^^^^^^^^^^^^^^^^^
   AttributeError: module 'xbmc' has no attribute 'translatePath'
   -->End of Python script error report
```

It looks like this API has been deprecated in kodiv19 and fully removed in kodiv20.

I tested the change locally and it looks like the authorisation dialog starts working and pops up.

I applied the suggested fix from here: https://forum.kodi.tv/showthread.php?tid=361955

Best regards
Entepotenz